### PR TITLE
Dlist remove last

### DIFF
--- a/dlistlib/dlistlib.go
+++ b/dlistlib/dlistlib.go
@@ -186,6 +186,7 @@ func (dl *DoublyLinkedList) RemoveValue(val string) error {
 	return notFoundError
 }
 
+// Method to remove the first element (head) of a doubly linked list
 func (dl *DoublyLinkedList) RemoveFirst() (*Node, error) {
 	if dl.IsNil() {
 		return nil, NilListError
@@ -198,9 +199,10 @@ func (dl *DoublyLinkedList) RemoveFirst() (*Node, error) {
 	removed := dl.head
 	dl.head = dl.head.next
 
-	//last element was removed
-	if dl.head == nil {
+	if dl.head == nil { //only element in the list was removed
 		dl.tail = nil
+	} else {
+		dl.head.prev = nil
 	}
 
 	return removed, nil
@@ -219,9 +221,10 @@ func (dl *DoublyLinkedList) RemoveLast() (*Node, error) {
 	removed := dl.tail
 	dl.tail = dl.tail.prev
 
-	//only element in the list was removed
-	if dl.tail == nil {
+	if dl.tail == nil { //only element in the list was removed
 		dl.head = nil
+	} else {
+		dl.tail.next = nil
 	}
 
 	return removed, nil

--- a/dlistlib/dlistlib.go
+++ b/dlistlib/dlistlib.go
@@ -205,3 +205,24 @@ func (dl *DoublyLinkedList) RemoveFirst() (*Node, error) {
 
 	return removed, nil
 }
+
+// Method to remove the last element (tail) of a doubly linked list
+func (dl *DoublyLinkedList) RemoveLast() (*Node, error) {
+	if dl.IsNil() {
+		return nil, NilListError
+	}
+
+	if dl.IsEmpty() {
+		return nil, EmptyListError
+	}
+
+	removed := dl.tail
+	dl.tail = dl.tail.prev
+
+	//only element in the list was removed
+	if dl.tail == nil {
+		dl.head = nil
+	}
+
+	return removed, nil
+}

--- a/dlistlib/dlistlib_test.go
+++ b/dlistlib/dlistlib_test.go
@@ -707,3 +707,16 @@ func TestRemoveFirst(t *testing.T) {
 		}
 	})
 }
+
+func TestRemoveLast(t *testing.T) {
+	var dl *DoublyLinkedList
+
+	t.Run("Nil list", func(t *testing.T) {
+		_, err := dl.RemoveLast()
+		if err == nil {
+			t.Errorf("Removing the last element of a nil list should have failed")
+		} else {
+			fmt.Println(err)
+		}
+	})
+}

--- a/dlistlib/dlistlib_test.go
+++ b/dlistlib/dlistlib_test.go
@@ -719,4 +719,14 @@ func TestRemoveLast(t *testing.T) {
 			fmt.Println(err)
 		}
 	})
+
+	dl = &DoublyLinkedList{}
+	t.Run("Empty list", func(t *testing.T) {
+		_, err := dl.RemoveLast()
+		if err == nil {
+			t.Errorf("Removing the last element of an empty list should have failed")
+		} else {
+			fmt.Println(err)
+		}
+	})
 }

--- a/dlistlib/dlistlib_test.go
+++ b/dlistlib/dlistlib_test.go
@@ -729,4 +729,30 @@ func TestRemoveLast(t *testing.T) {
 			fmt.Println(err)
 		}
 	})
+
+	dl = &DoublyLinkedList{}
+	t.Run("Single Element list", func(t *testing.T) {
+		err := dl.AddAtEnd("a")
+		if err != nil {
+			t.Errorf("Adding to a list failed, error: %v", err)
+		} else {
+			removed, err2 := dl.RemoveLast()
+			if err2 != nil {
+				t.Errorf("Removing the last element from a single element list failed, error:  %v", err2)
+			} else {
+
+				want := "a"
+				got := removed.String()
+				if got != want {
+					t.Errorf("Removed element from a list is incorrect, want: %v, got %v", want, got)
+				}
+
+				want = "empty"
+				got = dl.String()
+				if got != want {
+					t.Errorf("Removing the only value from a single element list should result in an empty list")
+				}
+			}
+		}
+	})
 }

--- a/dlistlib/dlistlib_test.go
+++ b/dlistlib/dlistlib_test.go
@@ -755,4 +755,67 @@ func TestRemoveLast(t *testing.T) {
 			}
 		}
 	})
+
+	dl = &DoublyLinkedList{}
+	t.Run("Remove last till list is empty", func(t *testing.T) {
+		vals := []string{"a", "b", "c", "d", "e"}
+
+		for _, v := range vals {
+			err := dl.AddAtEnd(v)
+			if err != nil {
+				t.Fatalf("Adding to a list failed, error: %v", err)
+			}
+		}
+
+		removed := []string{"e", "d", "c", "b", "a"}
+		partials := []string{
+			"nil<-a<=>b<=>c<=>d->nil",
+			"nil<-a<=>b<=>c->nil",
+			"nil<-a<=>b->nil",
+			"nil<-a->nil",
+			"empty",
+		}
+		heads := []string{"a", "a", "a", "a", "nil"}
+		tails := []string{"d", "c", "b", "a", "nil"}
+		for i := 0; !dl.IsEmpty(); i++ {
+			rem, err := dl.RemoveLast()
+			if err != nil {
+				t.Errorf("Removing from a list failed, error: %v", err)
+			} else {
+				want := removed[i]
+				got := rem.String()
+
+				if got != want {
+					t.Errorf("Removed element from a list is incorrect, want: %v, got %v", want, got)
+				}
+
+				want = partials[i]
+				got = dl.String()
+
+				if got != want {
+					t.Errorf("Incorrect list after removing the last element, want: %v, got: %v", want, got)
+				}
+
+				want = heads[i]
+				got = dl.head.String()
+				if got != want {
+					t.Errorf("Incorrect head after removing the last element, want: %v, got: %v", want, got)
+				}
+
+				want = tails[i]
+				got = dl.tail.String()
+				if got != want {
+					t.Errorf("Incorrect tail after removing the last element, want: %v, got: %v", want, got)
+				}
+
+				if dl.tail != nil {
+					want = "nil"
+					got = dl.tail.next.String()
+					if got != want {
+						t.Errorf("tail's next pointer should always be nil, want: %v, got: %v", want, got)
+					}
+				}
+			}
+		}
+	})
 }

--- a/dlistlib/dlistlib_test.go
+++ b/dlistlib/dlistlib_test.go
@@ -703,6 +703,14 @@ func TestRemoveFirst(t *testing.T) {
 				if got != want {
 					t.Errorf("Incorrect tail after removing the first element, want: %v, got: %v", want, got)
 				}
+
+				if dl.head != nil {
+					want = "nil"
+					got = dl.head.prev.String()
+					if got != want {
+						t.Errorf("head's prev pointer should always be nil, want: %v, got: %v", want, got)
+					}
+				}
 			}
 		}
 	})


### PR DESCRIPTION
- added a method to remove the last element of a doubly linked list
- added tests for the same
- fixed a bug in remove first / last methods where pointers of new head / tail were not set correctly